### PR TITLE
Fix: Assertion Failed: The key provided to get must be a string or number , you passed undefined

### DIFF
--- a/addon/services/visibility.js
+++ b/addon/services/visibility.js
@@ -85,10 +85,11 @@ export default Service.extend({
    * Event handler.
    */
   _handleDocumentVisibilityChange() {
+    if (this.isDestroyed || this.isDestroying) { return; }
+
     const hiddenFlagName = this.get('pageVisibilityAPI.hiddenFlag');
     const isHidden = get(document, hiddenFlagName);
 
-    if (this.isDestroyed) { return; }
 
     this.set('visible', !isHidden);
 


### PR DESCRIPTION
Hi,

I've found a problem with the `visibility` service. Turns out that `this.get` returns `undefined` when the context is being destroyed or is already destroyed and your pass a path (dot separated) key. This is causing  https://github.com/elwayman02/ember-is-visible/blob/master/addon/services/visibility.js#L89 to fail at the assertion `The key provided to get must be a string or number , you passed undefined` as `hiddenFlagName` is `undefined`.

I've fixed it by moving the destroyed check to the top of the function, to prevent any code whatsoever being run as the result will be a noop anyways.

Thank you